### PR TITLE
- Rewrite hero intro with a stronger professional summary; drop inline

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="public/favicon.ico" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#1F1F23" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Talha Saleem — Full Stack Software Engineer based in New Jersey, specializing in .NET and React/Node.js."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>MSPortfolio</title>
+    <title>Talha Saleem | Full Stack Software Engineer</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@
  */
 import { Navbar } from "./components/Navbar";
 import { Welcome } from "./components/Welcome";
+import { Skills } from "./components/Skills";
 import { Projects } from "./components/Projects";
 import { Footer } from "./components/Footer";
 function App() {
@@ -10,8 +11,9 @@ function App() {
     <div className="App">
       <Navbar/>
       <Welcome/>
+      <Skills/>
       <Projects/>
-      <Footer/>      
+      <Footer/>
     </div>
   );
 }

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,6 +1,6 @@
 
 export const Footer = () => {
   return (
-    <p className="Footer">All Rights Rerserved M.Saleem.</p>
+    <p className="Footer">All Rights Reserved T.Saleem.</p>
   )
 }

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -7,25 +7,25 @@ export const Navbar = () => {
 <nav className="bg-[#1F1F23] border-b border-[#2A2D3A] shadow-lg">
   <section className="flex flex-col sm:flex-row sm:justify-between sm:items-center py-3 px-3 sm:px-0">
     <div className="flex justify-center sm:justify-start mb-2 sm:mb-0">
-      <h2 className="ml-0 sm:ml-5 hidden sm:inline text-sm sm:text-base text-[#F9FAFB] font-medium">Muhammad Saleem</h2>
-      <h2 className="inline sm:hidden text-sm text-[#F9FAFB] font-medium">Muhammad S.</h2>
+      <h2 className="ml-0 sm:ml-5 hidden sm:inline text-sm sm:text-base text-[#F9FAFB] font-medium">Talha Saleem</h2>
+      <h2 className="inline sm:hidden text-sm text-[#F9FAFB] font-medium">Talha S.</h2>
     </div>
 
     <div className="flex gap-2 justify-center sm:justify-end sm:mr-5">
       <a href="https://docs.google.com/document/d/10wZtw66yET-sdO3I9PtcoTsS8rDbIelfZCxo2NqBjfc/edit?tab=t.0" target="_blank" rel="noreferrer">
-        <button className="bg-[#1F1F23] hover:bg-[#1F2937] text-[#F9FAFB] hover:text-[#D1D5DB] font-bold py-2 px-2 sm:px-3 border border-[#4B5563] hover:border-[#374151] rounded text-xs sm:text-sm transition-all duration-300 hover:shadow-md">
+        <button className="bg-[#1F1F23] hover:bg-[#9D8DF1] text-[#F9FAFB] hover:text-[#1F1F23] font-bold py-2 px-2 sm:px-3 border border-[#4B5563] hover:border-[#9D8DF1] rounded text-xs sm:text-sm transition-all duration-300 hover:shadow-md">
           Resume
         </button>
       </a>
       
       <a href="mailto:t_sal@hotmail.com">
-        <button className="bg-[#1F1F23] hover:bg-[#1F2937] text-[#F9FAFB] hover:text-[#D1D5DB] font-bold py-2 px-2 sm:px-3 border border-[#4B5563] hover:border-[#374151] rounded text-xs sm:text-sm transition-all duration-300 hover:shadow-md">
+        <button className="bg-[#1F1F23] hover:bg-[#9D8DF1] text-[#F9FAFB] hover:text-[#1F1F23] font-bold py-2 px-2 sm:px-3 border border-[#4B5563] hover:border-[#9D8DF1] rounded text-xs sm:text-sm transition-all duration-300 hover:shadow-md">
           Email
         </button>
       </a>
 
       <a href="https://github.com/Tsaleem123/" target="_blank" rel="noreferrer">
-        <button className="bg-[#1F1F23] hover:bg-[#1F2937] text-[#F9FAFB] hover:text-[#D1D5DB] font-bold py-2 px-2 sm:px-3 border border-[#4B5563] hover:border-[#374151] rounded text-xs sm:text-sm transition-all duration-300 hover:shadow-md">
+        <button className="bg-[#1F1F23] hover:bg-[#9D8DF1] text-[#F9FAFB] hover:text-[#1F1F23] font-bold py-2 px-2 sm:px-3 border border-[#4B5563] hover:border-[#9D8DF1] rounded text-xs sm:text-sm transition-all duration-300 hover:shadow-md">
           Github
         </button>
       </a>

--- a/src/components/Project.js
+++ b/src/components/Project.js
@@ -1,7 +1,7 @@
 export const Project = ({ Title, Para, Img , TechList }) => {
   return (
     <div className="flex justify-center my-10">
-      <div className="rounded-lg shadow-lg bg-[#2A2D3A] border border-[#374151] max-w-2xl hover:scale-105 hover:shadow-xl hover:border-[#4B5563] transition-all duration-300 ease-in-out">
+      <div className="rounded-lg shadow-lg bg-[#2A2D3A] border border-[#374151] max-w-2xl hover:scale-105 hover:shadow-xl hover:border-[#9D8DF1] hover:bg-[#9D8DF1]/10 transition-all duration-300 ease-in-out">
         <img className="max-h-96 mx-auto my-10 rounded-xl shadow-md" src={Img} alt="" />
         
         <div className="px-6 pb-6">
@@ -14,7 +14,7 @@ export const Project = ({ Title, Para, Img , TechList }) => {
             {TechList.map((item, index) => (
               <span 
                 key={index} 
-                className="bg-[#374151] text-[#D1D5DB] px-3 py-1 rounded-full text-sm font-medium border border-[#4B5563] hover:bg-[#4B5563] hover:text-[#F9FAFB] transition-colors duration-200"
+                className="bg-[#374151] text-[#D1D5DB] px-3 py-1 rounded-full text-sm font-medium border border-[#4B5563]"
               >
                 {item}
               </span>

--- a/src/components/Projects.js
+++ b/src/components/Projects.js
@@ -7,7 +7,7 @@ import * as MV from './MagicVariables';
 export const Projects = () => {
   return (
     <section className = "Projects">
-    <h1> Projects: </h1>
+    <h1>Projects</h1>
     <a href={MV.GameInventoryLink} target="_blank" rel="noreferrer" >
     <Project Title = {MV.GameInventoryTitle} Para = {MV.GameInventoryPara} Img = {MV.GameInventoryImg} TechList = {MV.GameInventoryList}/>
     </a>

--- a/src/components/Skills.js
+++ b/src/components/Skills.js
@@ -1,0 +1,41 @@
+/**
+ * Skills section — grouped tech chips (Languages, Frameworks, Tools).
+ */
+const skillGroups = [
+  {
+    label: "Languages",
+    items: ["C#", "Java", "JavaScript", "TypeScript", "Python", "SQL", "HTML/CSS"],
+  },
+  {
+    label: "Frameworks & Libraries",
+    items: [".NET", "Node.js", "Express", "React", "Angular", "Material UI", "MS Test", "Jest"],
+  },
+  {
+    label: "Development Tools",
+    items: ["Git", "GitHub", "Android Studio", "Docker"],
+  },
+];
+
+export const Skills = () => {
+  return (
+    <section className="Skills">
+      <div className="SkillGroups">
+        {skillGroups.map((group) => (
+          <div className="SkillGroup" key={group.label}>
+            <h3>{group.label}</h3>
+            <div className="flex flex-wrap gap-2 justify-center">
+              {group.items.map((item) => (
+                <span
+                  key={item}
+                  className="bg-[#374151] text-[#D1D5DB] px-3 py-1 rounded-full text-sm font-medium border border-[#4B5563]"
+                >
+                  {item}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/src/components/Welcome.js
+++ b/src/components/Welcome.js
@@ -2,10 +2,15 @@ export const Welcome = () => {
   return (
     <section className="Welcome">
       <h1 className="HeaderOne">
-        I'm Talha, I'm a developer based in New Jersey.{"\n"}Computer Science
-        graduate with a passion for learning + writing clean and reusable code.
-        Strong foundation in OOP Programming.
-      </h1>{" "}
+        I’m Talha, a{" "}
+        <span style={{ color: "var(--accent-blue)" }}>
+          Full Stack Software Engineer
+        </span>{" "}
+        based in New Jersey with 2 years of experience.{"\n"}I build and
+        modernize web applications, and I’m passionate about creating clean,
+        reusable, and maintainable code that stands the test of time. Building
+        software that serves people well gives me a deep sense of fulfillment.
+      </h1>
     </section>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,7 @@
 Professional Dark Theme Portfolio Color Variables
 Primary: Dark Charcoal - #1F1F23 (Modern dark background)
 Secondary: Medium Dark - #2A2D3A (Elevated surfaces)
-Accent: Electric Blue - #60A5FA (Vibrant accent, easy on eyes)
+Accent: Periwinkle - #9D8DF1 (Soft violet accent)
 Surface: Dark Gray - #374151 (Cards and sections)
 Text White: Off White - #F9FAFB (Primary text)
 Text Gray: Light Gray - #D1D5DB (Secondary text)
@@ -19,7 +19,7 @@ Text Gray: Light Gray - #D1D5DB (Secondary text)
   --primary-dark: #1F1F23;
   --secondary-dark: #2A2D3A;
   --surface-dark: #374151;
-  --accent-blue: #60A5FA;
+  --accent-blue: #9D8DF1;
   --text-white: #F9FAFB;
   --text-gray: #D1D5DB;
   --text-muted: #9CA3AF;
@@ -28,19 +28,24 @@ Text Gray: Light Gray - #D1D5DB (Secondary text)
 
 @keyframes transitionIn {
   from {
-    opacity: 0%;
+    opacity: 0;
+    transform: translateY(8px);
   }
 
   to {
-    opacity: 100%;
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 
 * {
-  animation: transitionIn 2s cubic-bezier(1, -0.4, 0, 1);
   padding: 0;
   margin: 0;
   box-sizing: border-box;
+}
+
+.App > * {
+  animation: transitionIn 0.8s ease-out both;
 }
 
 h1,
@@ -61,7 +66,44 @@ body {
 .Projects {
   text-align: center;
   padding-top: 50px;
+  padding-bottom: 30px;
   background-color: var(--primary-dark);
+}
+
+.Projects h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  display: inline-block;
+  padding-bottom: 0.5rem;
+  border-bottom: 3px solid var(--accent-blue);
+}
+
+.Skills {
+  text-align: center;
+  padding: 0 1rem 4rem;
+  background-color: var(--secondary-dark);
+}
+
+.SkillGroups {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem 2rem;
+  max-width: 56rem;
+  margin: 0 auto;
+  align-items: start;
+}
+
+.SkillGroup h3 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--accent-blue);
+  margin-bottom: 0.85rem;
+}
+
+@media only screen and (max-width: 640px) {
+  .SkillGroups {
+    grid-template-columns: 1fr;
+  }
 }
 
 .Card {
@@ -72,11 +114,10 @@ body {
 }
 
 .HeaderOne {
-  display: inline-block;
   text-align: center;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  max-width: 50rem;
+  margin: 0 auto;
+  line-height: 1.4;
 }
 
 .HeaderTwo {
@@ -91,8 +132,8 @@ body {
   font-size: 1.5rem;
   color: var(--text-white);
   text-align: center;
-  padding-top: 10rem;
-  padding-bottom: 10rem;
+  padding-top: 5rem;
+  padding-bottom: 2.5rem;
   background-color: var(--secondary-dark);
 }
 
@@ -114,7 +155,7 @@ body {
 nav a {
   padding-right: 2rem;
   text-decoration: none;
-  font-weight: 100px;
+  font-weight: 400;
   color: var(--text-white);
 }
 


### PR DESCRIPTION
  skill list and highlight key phrases in the accent color
- Add a Skills section (Languages / Frameworks & Libraries / Dev Tools) as a compact 3-column chip layout sharing the hero background
- Switch accent color to periwinkle (#9D8DF1) site-wide
- Restyle navbar buttons and project cards with accent hover states (filled buttons, tinted card hover); remove tech-chip hover effect
- Rename "Muhammad Saleem" to "Talha Saleem" in navbar/footer; fix "Rerserved" typo
- Fix page metadata: title, description, favicon path, theme color
- Scope the fade-in animation to top-level sections (was applied to *)